### PR TITLE
Added SafeNet platform

### DIFF
--- a/src/org/lockss/app/LockssDaemon.java
+++ b/src/org/lockss/app/LockssDaemon.java
@@ -265,6 +265,7 @@ private final static String LOCKSS_USER_AGENT = "LOCKSS cache";
 
   private static LockssDaemon theDaemon;
   private boolean isClockss;
+  private boolean isSafenet;
   protected String testingMode;
 
   protected LockssDaemon(List<String> propUrls) {
@@ -328,6 +329,13 @@ private final static String LOCKSS_USER_AGENT = "LOCKSS cache";
    */
   public boolean isDetectClockssSubscription() {
     return isClockss() && getClockssParams().isDetectSubscription();
+  }
+
+  /**
+   * True if running as a Safenet daemon
+   */
+  public boolean isSafenet() {
+    return isSafenet;
   }
 
   /** Stop the daemon.  Currently only used in testing. */
@@ -954,6 +962,7 @@ private final static String LOCKSS_USER_AGENT = "LOCKSS cache";
     testingMode = config.get(PARAM_TESTING_MODE);
     String proj = ConfigManager.getPlatformProject();
     isClockss = "clockss".equalsIgnoreCase(proj);
+    isSafenet = "safenet".equalsIgnoreCase(proj);
 
     super.setConfig(config, prevConfig, changedKeys);
   }


### PR DESCRIPTION
As part of the SafeNet project, we're going to be customising a number of things, mainly in the way ServeContent works. To isolate these changes from the rest of the the codebase, we've started by using the platform configuration parameter to determine if this is 'SafeNet' or not.

This change by itself doesn't really add any functionality, the main functionality exists in [a further branch](https://github.com/lockss/lockss-daemon/compare/master...edina:add_safenet_serve_content?expand=1), but we thought we'd separate this out to make reviewing easier. Our current plan was to raise an additional PR to merge in that branch, but let us know if you'd like us to divide it up further