### PR TITLE
Quick Fix for SubscripttonManagement servlet

### DIFF
--- a/src/org/lockss/servlet/SubscriptionManagement.java
+++ b/src/org/lockss/servlet/SubscriptionManagement.java
@@ -2793,17 +2793,21 @@ public class SubscriptionManagement extends LockssServlet {
 	    if (log.isDebug3()) log.debug3(DEBUG_HEADER
 		+ "oldPublisherSubscriptionSetting = "
 		+ oldPublisherSubscriptionSetting);
-
+	    
+	    String id = (PUBLISHER_SUBSCRIPTION_WIDGET_ID_PREFIX
+		+ publisherSubscription.getPublisher().getPublisherSeq())
+		.trim();
 	    Boolean newPublisherSubscriptionSetting = getTriBoxValue(
-		parameterMap,
-		PUBLISHER_SUBSCRIPTION_WIDGET_ID_PREFIX
-		+ publisherSubscription.getPublisher().getPublisherSeq());
+		parameterMap, id);
 	    if (log.isDebug3()) log.debug3(DEBUG_HEADER
 		+ "newPublisherSubscriptionSetting = "
 		+ newPublisherSubscriptionSetting);
 
-	    publisherSubscription
-	    .setSubscribed(newPublisherSubscriptionSetting);
+	    if(parameterMap
+		.get(id + TRI_STATE_WIDGET_HIDDEN_ID_SUFFIX) != null ){
+  	    	publisherSubscription
+  	    	.setSubscribed(newPublisherSubscriptionSetting);
+	    }
 
 	    // Get an indication of whether the publisher subscription has been
 	    // changed.


### PR DESCRIPTION
## Proposed changes

The UpdateSubscriptions() function was considering a subsciption with
missing status parameter as a 'subscription to update to unset'.

It mainly because the getTriBoxValue function return the same thing
whether the value of the parameter is 'null' or 'unset'.

Therefore, this fix simply make sure the parameter wasn't 'null' before
updating the subscription.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature modification (Fix or feature that will cause existing functionality to not work as expected)

## Checklist

- [ ] Read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] Maintained the existing coding style and format
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Added necessary documentation (if appropriate)
- [ ] Rebase and squash my commits. Submit one commit only, on top of the master branch.

## Further comments

This hasn't been tested at all.
