### PR TITLE
Broaden DOI substring match to preferred resolver

### DIFF
--- a/plugins/src/org/lockss/plugin/clockss/iop/IopOnixXmlMetadataExtractorFactory.java
+++ b/plugins/src/org/lockss/plugin/clockss/iop/IopOnixXmlMetadataExtractorFactory.java
@@ -227,8 +227,8 @@ public class IopOnixXmlMetadataExtractorFactory extends SourceXmlMetadataExtract
       String fullDOI = (helper == Onix2Helper) ? oneAM.getRaw(Onix2BooksSchemaHelper.ONIX_idtype_doi) : 
         oneAM.getRaw(Onix3BooksSchemaHelper.ONIX_idtype_doi);
       String clean_doi = null;
-      if (fullDOI != null && fullDOI.contains("dx.doi.org")) {
-        clean_doi = StringUtils.substringAfter(fullDOI,"http://dx.doi.org/");
+      if (fullDOI != null && fullDOI.contains("doi.org")) {
+        clean_doi = StringUtils.substringAfter(fullDOI,"doi.org/");
         if (!(fullDOI.equals(clean_doi))) {
             oneAM.putIfBetter(MetadataField.FIELD_DOI,clean_doi);
         }


### PR DESCRIPTION
## Proposed changes

1. Brief description of changes applied

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). I was wondering whether the attached change could be used to match both the old and new resolver URLs. Or would `substringAfter` need to be replaced with a reg-ex matching function? 

2. Any documentation on how to configure, test
3. Any possible limitations, side effects, etc.

Currently yes, see `Further comments`, but might not be, if applied everywhere.

4. Reference any other pull requests that might be related.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature modification (Fix or feature that will cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] Maintained the existing coding style and format
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Added necessary documentation (if appropriate)
- [x] Rebase and squash my commits. Submit one commit only, on top of the master branch.

## Further comments

This will probably need to expand, because there are many other instances of `dx.doi.org` being used in reg-exes, etc.: https://github.com/lockss/lockss-daemon/search?l=Java&q=dx.doi&type=


### Reviewers: @tlipkis, @clairegriffin, ...

Thanks for your contribution. 
